### PR TITLE
feat(23.11 /client/src/components/FilterSize): added price slider filter

### DIFF
--- a/client/src/components/FilterPrice/FilterPrice.jsx
+++ b/client/src/components/FilterPrice/FilterPrice.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export default function FilterPrice() {
+	let prices = [0, 45, 32, 199, 344, 21, 8, 76];
+	let maxPrice = Math.max(...prices);
+	let roundUpMax = (Math.trunc(maxPrice / 100) + 1) * 100;
+
+	let [value, setValue] = useState(roundUpMax);
+
+	function onChangeHandler(e) {
+		setValue(e.target.value);
+		console.log(e.target.value);
+	}
+
+	return (
+		<div>
+			<div>Price</div>
+			<input
+				type='range'
+				min='0'
+				max={roundUpMax}
+				step='50'
+				value={value}
+				onChange={onChangeHandler}
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
Filter by price component added. As usual, it uses a dummy set of numbers stored in an array for now.

It takes the max value within that array and rounds it up to its nearest hundred and uses that as its max value in the slider.

Min value is set to 0 and increments are in steps of 50.